### PR TITLE
:sid tag no longer exists

### DIFF
--- a/fluent-bit/config.json
+++ b/fluent-bit/config.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-bit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "slug": "fluent_bit",
   "description": "Fluent-Bit log shipping",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/fluent-bit/run.py
+++ b/fluent-bit/run.py
@@ -9,8 +9,7 @@ with open("/data/options.json", "r") as options_file:
     options = json.loads(options_file.read())
     print(f"Using options: {options}")
 
-#CONTAINER_IMAGE = "fluent/fluent-bit"
-CONTAINER_IMAGE = "fluent/fluent-bit:sid"  # usage sid-based image with newer libsystemd-dev
+CONTAINER_IMAGE = "fluent/fluent-bit" # go back to latest; sid no longer exists
 FORWARDER_CONTAINER_NAME = "addon_fluent_bit_forwarder"
 FLUENT_BIT_COMMAND = [
     "/fluent-bit/bin/fluent-bit",


### PR DESCRIPTION
Hello! Just a quick PR - the `:sid` tag for fluent-bit no longer exists, so I presume they merged it back into `latest` 😄 